### PR TITLE
Loging to influxdb v2 using token,org

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ project accordingly also into metric units. The values of both unit systems are 
 ### Influx DB
 
 The measured values received by the weather station can be written into an influx database. Influx settings are set via
-config file (see config example below).
+config file (see config example below). The implementation is compatible with influxdb v1 and v2. 
 
 ### HTTP JSON
 
@@ -88,10 +88,10 @@ influxDbExporter:
   enabled: false
   server: 1.2.3.4
   port: 8086
-  user: user
-  password: password
-  database: database
-  measurement: measurement
+  org: <org>
+  token: <token> or <username>:<password>
+  database: <database(bucket)>
+  measurement: <measurement>
 
 mqtt:
   enabled: false

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -12,10 +12,10 @@ influxDbExporter:
   enabled: false
   server: 1.2.3.4
   port: 8086
-  user: user
-  password: password
   database: database
-  measurement: measurement
+  measurement: measurement(database)
+  token: token
+  org : org
 
 mqtt:
   enabled: false

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -12,10 +12,10 @@ influxDbExporter:
   enabled: false
   server: 1.2.3.4
   port: 8086
-  database: database(bucket)
-  measurement: measurement
-  token: token
-  org : org
+  org: <org>
+  token: <token> or <username>:<password>
+  database: <database(bucket)>
+  measurement: <measurement>
 
 mqtt:
   enabled: false

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -12,8 +12,8 @@ influxDbExporter:
   enabled: false
   server: 1.2.3.4
   port: 8086
-  database: database
-  measurement: measurement(database)
+  database: database(bucket)
+  measurement: measurement
   token: token
   org : org
 

--- a/exporter/influxDb/influxExporter.go
+++ b/exporter/influxDb/influxExporter.go
@@ -5,6 +5,7 @@ import (
 	"bresser-weather-exporter/model/configuration"
 	"context"
 	"fmt"
+
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/influxdata/influxdb-client-go/v2/api"
 	log "github.com/sirupsen/logrus"
@@ -21,9 +22,9 @@ func SetupInfluxDb(config *configuration.Configuration) {
 		log.Info("Configuring influx db...")
 		influxClient = influxdb2.NewClient(
 			fmt.Sprintf("http://%s:%d", config.InfluxDbExporter.Server, config.InfluxDbExporter.Port),
-			fmt.Sprintf("%s:%s", config.InfluxDbExporter.Username, config.InfluxDbExporter.Password),
+			fmt.Sprintf("%s", config.InfluxDbExporter.Token),
 		)
-		influxWriteAPI = influxClient.WriteAPIBlocking("", config.InfluxDbExporter.Database)
+		influxWriteAPI = influxClient.WriteAPIBlocking(config.InfluxDbExporter.Org, config.InfluxDbExporter.Database)
 		measurementName = config.InfluxDbExporter.Measurement
 	}
 }

--- a/model/configuration/influx.go
+++ b/model/configuration/influx.go
@@ -4,8 +4,8 @@ type InfluxExporterConfiguration struct {
 	Enabled     bool
 	Server      string
 	Port        int
-	Username    string
-	Password    string
 	Database    string
 	Measurement string
+	Token       string
+	Org         string
 }


### PR DESCRIPTION
Some changes to allow write to influxdb v2. Use token instead of password, username. Add org.